### PR TITLE
inialize nano-buffer with predefined array

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ buffer.maxSize = 20;
 console.log(buffer.maxSize); // 20
 ```
 
+#### `maxSize` Number
+
+Gets default max size. It's possible in the future a configuration option, defining default maximal buffer size, will be added 
+
+```js
+const buffer = new NanoBuffer(2);
+
+console.log(buffer.size); // 0
+console.log(buffer.maxSize); // 2
+console.log(buffer.defaultMaxSize); // 10
+```
+
 #### `size` Number
 
 Gets the number of values in the buffer. This will never exceed the `maxSize`.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,24 @@ for (const value of buffer) {
 
 ### Constructor
 
-#### `new NanoBuffer(maxSize=10)`
+There are four possible constructor signatures.
 
-Creates a new `NanoBuffer` instance with the specified max size. Default max size is `10`.
+#### `new NanoBuffer()`
+
+Creates a new `NanoBuffer` instance. Default max size is `10`. 
+
+#### `new NanoBuffer(maxSize)`
+
+Creates a new `NanoBuffer` instance with the specified max size. 
+
+#### `new NanoBuffer(buffer)`
+
+Creates a new `NanoBuffer` instance initialised with predefined buffer. Max size is set to buffer length.
+
+#### `new NanoBuffer(buffer, maxSize)`
+
+Creates a new `NanoBuffer` instance initialised with predefined buffer. The second argument defines max size.
+
 
 ### Properties
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,15 +15,13 @@ export class NanoBuffer {
 			if (maxSize === undefined) {
 				maxSize = buffer.length;
 			}
-		} else {
-			if (typeof bufferOrMaxSize === 'undefined') {
-				maxSize = 10;
-			} else {
-				if (maxSize !== undefined) {
-					throw new TypeError('Second argument should not be given, if the first argument is a number');
-				}
-				maxSize = bufferOrMaxSize;
+		} else if (bufferOrMaxSize !== undefined || maxSize !== undefined) {
+			if (typeof bufferOrMaxSize === 'number' && maxSize !== undefined) {
+				throw new TypeError('Second argument should not be given, if the first argument is a number');
 			}
+			maxSize ??= bufferOrMaxSize;
+		} else {
+			maxSize = 10;
 		}
 		if (typeof maxSize !== 'number') {
 			throw new TypeError('Expected maxSize to be a number');

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,10 @@ export class NanoBuffer {
 		return this._maxSize;
 	}
 
+	/**
+	 * Returns current default maximal buffer size. It's possible in the future a configuration option will be added.
+	 * @return {number}
+	 */
 	get defaultMaxSize() {
 		return DEFAULT_MAX_SIZE;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,15 @@
 /**
  * A lightweight, fixed-size value buffer.
  */
+const DEFAULT_MAX_SIZE = 10;
+
 export class NanoBuffer {
 	/**
 	 * Creates a `NanoBuffer` instance.
 	 *
 	 * @param {Number} [maxSize=10] - The initial buffer size.
 	 */
-	constructor(maxSize = 10) {
+	constructor(maxSize = DEFAULT_MAX_SIZE) {
 		if (typeof maxSize !== 'number') {
 			throw new TypeError('Expected maxSize to be a number');
 		}
@@ -63,6 +65,10 @@ export class NanoBuffer {
 	 */
 	get maxSize() {
 		return this._maxSize;
+	}
+
+	get defaultMaxSize() {
+		return DEFAULT_MAX_SIZE;
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -41,16 +41,11 @@ export class NanoBuffer {
 			const bufferLength = buffer.length;
 			if (bufferLength > maxSize) {
 				safeSize = maxSize;
-				safeHead = bufferLength % maxSize;
-				const tailSize = maxSize - safeHead;
-				const breakIndex = -maxSize + tailSize;
-				safeBuffer = buffer.slice(breakIndex).concat(buffer.slice(-maxSize, breakIndex));
+				safeHead = maxSize - 1;
+				safeBuffer = buffer.slice(-maxSize);
 			} else {
 				safeBuffer = buffer;
 				safeSize = bufferLength;
-				safeHead = bufferLength;
-			}
-			if (--safeHead < 0) {
 				safeHead = bufferLength - 1;
 			}
 		}

--- a/test/test-nanobuffer.js
+++ b/test/test-nanobuffer.js
@@ -50,6 +50,13 @@ describe('NanoBuffer', () => {
 		expect(b.head).to.equal(5);
 	});
 
+	it('should be initialized without predefined array but with given size', () => {
+		const b = new NanoBuffer(undefined, 20);
+		expect(b.maxSize).to.equal(20);
+		expect(b.size).to.equal(0);
+		expect(b.head).to.equal(0);
+	});
+
 	it('should be initialized with a predefined array and a max size', () => {
 		const p = [ 'foo0', 'foo1', 'foo2', 'foo3', 'foo4', 'foo5' ];
 		const b = new NanoBuffer(p, 4);

--- a/test/test-nanobuffer.js
+++ b/test/test-nanobuffer.js
@@ -22,8 +22,40 @@ describe('NanoBuffer', () => {
 		}).to.throw(RangeError, 'Expected maxSize to be zero or greater');
 	});
 
-	it('should get the max size', () => {
-		expect(new NanoBuffer(20).maxSize).to.equal(20);
+	it('should throw error if given two wrong arguments', () => {
+		expect(() => {
+			new NanoBuffer(20, 10);
+		}).to.throw(TypeError, 'Second argument should not be given, if the first argument is a number');
+	});
+
+	it('should be default initialized', () => {
+		const b = new NanoBuffer();
+		expect(b.maxSize).to.equal(10);
+		expect(b.size).to.equal(0);
+		expect(b.head).to.equal(0);
+	});
+
+	it('should be initialized as an empty array with a predefined max size', () => {
+		const b = new NanoBuffer(20);
+		expect(b.maxSize).to.equal(20);
+		expect(b.size).to.equal(0);
+		expect(b.head).to.equal(0);
+	});
+
+	it('should be initialized with a predefined array', () => {
+		const p = [ 'foo0', 'foo1', 'foo2', 'foo3', 'foo4', 'foo5' ];
+		const b = new NanoBuffer(p);
+		expect(b.maxSize).to.equal(6);
+		expect(b.size).to.equal(6);
+		expect(b.head).to.equal(5);
+	});
+
+	it('should be initialized with a predefined array and a max size', () => {
+		const p = [ 'foo0', 'foo1', 'foo2', 'foo3', 'foo4', 'foo5' ];
+		const b = new NanoBuffer(p, 4);
+		expect(b.maxSize).to.equal(4);
+		expect(b.size).to.equal(4);
+		expect(b.head).to.equal(1);
 	});
 
 	it('should add an object', () => {
@@ -175,6 +207,38 @@ describe('NanoBuffer', () => {
 		}
 
 		let i = 0;
+		for (const it of b) {
+			expect(it).to.equal(`foo${i++}`);
+		}
+	});
+
+	it('should initialize the predefined buffer, which is smaller than max size', () => {}, () => {
+		const p = [ 'foo0', 'foo1', 'foo2', 'foo3', 'foo4' ];
+
+		const b = new NanoBuffer(10, p);
+
+		let i = 0;
+		for (const it of b) {
+			expect(it).to.equal(`foo${i++}`);
+		}
+	});
+
+	it('should initialize the predefined buffer, which length equals to max size', () => {
+		const p = [ 'foo0', 'foo1', 'foo2', 'foo3', 'foo4', 'foo5', 'foo6', 'foo7', 'foo8', 'foo9' ];
+		const b = new NanoBuffer(p, 10);
+
+		let i = 0;
+		for (const it of b) {
+			expect(it).to.equal(`foo${i++}`);
+		}
+	});
+
+	it('should initialize the predefined buffer, which is larger than max size', () => {
+		const p = [ 'foo0', 'foo1', 'foo2', 'foo3', 'foo4', 'foo5', 'foo6', 'foo7', 'foo8', 'foo9', 'foo10', 'foo11', 'foo12' ];
+
+		const b = new NanoBuffer(p, 10);
+
+		let i = 3;
 		for (const it of b) {
 			expect(it).to.equal(`foo${i++}`);
 		}

--- a/test/test-nanobuffer.js
+++ b/test/test-nanobuffer.js
@@ -26,6 +26,14 @@ describe('NanoBuffer', () => {
 		expect(new NanoBuffer(20).maxSize).to.equal(20);
 	});
 
+	it('should get the default max size', () => {
+		expect(new NanoBuffer().defaultMaxSize).to.equal(10);
+	});
+
+	it('should the default max size not changed on explicit max size', () => {
+		expect(new NanoBuffer(20).defaultMaxSize).to.equal(10);
+	});
+
 	it('should add an object', () => {
 		const b = new NanoBuffer;
 		expect(b.size).to.equal(0);

--- a/test/test-nanobuffer.js
+++ b/test/test-nanobuffer.js
@@ -55,7 +55,7 @@ describe('NanoBuffer', () => {
 		const b = new NanoBuffer(p, 4);
 		expect(b.maxSize).to.equal(4);
 		expect(b.size).to.equal(4);
-		expect(b.head).to.equal(1);
+		expect(b.head).to.equal(3);
 	});
 
 	it('should add an object', () => {


### PR DESCRIPTION
NanoBuffer will support four constructor signatures.

#### `new NanoBuffer()`

Creates a new `NanoBuffer` instance. Default max size is `10`. 

#### `new NanoBuffer(maxSize)`

Creates a new `NanoBuffer` instance with the specified max size. 

#### `new NanoBuffer(buffer)`

Creates a new `NanoBuffer` instance initialised with predefined buffer. Max size is set to buffer length.

#### `new NanoBuffer(buffer, maxSize)`

Creates a new `NanoBuffer` instance initialised with predefined buffer. The second argument defines max size.
